### PR TITLE
Generalize usage of `as_topy`

### DIFF
--- a/src/BPDual.jl
+++ b/src/BPDual.jl
@@ -10,7 +10,6 @@ function bpdual(
     active::Union{Nothing, Vector{Int}} = nothing, ## maybe write as struct later
     state::Union{Nothing, Vector{Int}} = nothing,
     y::Union{Nothing, Vector{Float64}} = nothing,
-    # S::Union{Nothing, Matrix{Float64}} = nothing,
     S = Matrix{Float64}(undef, size(A, 1), 0),
     R::Union{Nothing, Matrix{Float64}} = nothing,
     loglevel::Int = 1,
@@ -24,7 +23,6 @@ function bpdual(
     gapTol::Real = 1e-06,
     pivTol::Real = 1e-12,
     actMax::Real = Inf)
-
 
     # start 
     time0 = time()
@@ -106,7 +104,6 @@ function bpdual(
     svar      = ""     # string value
     r         = zeros(m)
     zerovec   = zeros(n)
-    nBrks     = 0
     numtrim   = 0
     nprodA    = 0
     nprodAt   = 0
@@ -145,7 +142,6 @@ function bpdual(
     #     end
     # end
 
-
     sL, sU = infeasibilities(bl, bu, vec(z))
     inactive = abs.(state) .!= 1
     state[inactive .& (sL .> feaTol)] .= -2
@@ -156,8 +152,6 @@ function bpdual(
     if infeasible
         eFlag = :EXIT_INFEASIBLE
     end
-
-
 
     # ------------------------------------------------------------------
     # Main loop.
@@ -193,7 +187,7 @@ function bpdual(
         rNorm = norm(r,2)
         xNorm = norm(x,1)
         
-        pObj, dObj, rGap = objectives(x,y,active,b,bl,bu,λ,rNorm,yNorm)
+        _, dObj, rGap = objectives(x,y,active,b,bl,bu,λ,rNorm,yNorm)
         nact = length(active)    
 
         if loglevel>0

--- a/src/BPDual.jl
+++ b/src/BPDual.jl
@@ -10,7 +10,8 @@ function bpdual(
     active::Union{Nothing, Vector{Int}} = nothing, ## maybe write as struct later
     state::Union{Nothing, Vector{Int}} = nothing,
     y::Union{Nothing, Vector{Float64}} = nothing,
-    S::Union{Nothing, Matrix{Float64}} = nothing,
+    # S::Union{Nothing, Matrix{Float64}} = nothing,
+    S = Matrix{Float64}(undef, size(A, 1), 0),
     R::Union{Nothing, Matrix{Float64}} = nothing,
     loglevel::Int = 1,
     coldstart::Bool = true,
@@ -343,7 +344,7 @@ function bpdual(
             # Delete an active constraint.
             if drop
                 nact = length(active)
-                _,qa = findmax(abs.(x .* dropa))
+                _, qa = findmax(abs.(x .* dropa))
                 q = active[qa]
                 state[q] = 0
                 S = S[:, 1:nact .!= qa]

--- a/src/homotopy.jl
+++ b/src/homotopy.jl
@@ -1,12 +1,10 @@
-
-
-function as_topy(A, b; min_lambda = 0.0, 
-                       homotopy = true, 
-                       kwargs...)
-    m,n = size(A)
+function asp_homotopy(A, b; min_lambda = 0.0, 
+                      homotopy = true, 
+                      kwargs...)
+    n = size(A, 2)
     bl = -ones(n)
     bu = +ones(n)
-    active,state,xx,y,S,R, tracer = bpdual(A, b, min_lambda, bl, bu;
+    active, _, xx, _, _, _, tracer = bpdual(A, b, min_lambda, bl, bu;
                              homotopy = homotopy, 
                              kwargs...)
     # BPdual's solution x is short. Make it full length.

--- a/src/homotopy.jl
+++ b/src/homotopy.jl
@@ -1,10 +1,14 @@
 
 
-function as_topy(A, b, lam)
+function as_topy(A, b; min_lambda = 0.0, 
+                       homotopy = true, 
+                       kwargs...)
     m,n = size(A)
     bl = -ones(n)
     bu = +ones(n)
-    active,state,xx,y,S,R, tracer = bpdual(A, b, lam, bl, bu, homotopy = true)
+    active,state,xx,y,S,R, tracer = bpdual(A, b, min_lambda, bl, bu;
+                             homotopy = homotopy, 
+                             kwargs...)
     # BPdual's solution x is short. Make it full length.
     x = zeros(n)
     x[active] = xx


### PR DESCRIPTION
I exposed all kw args from `bpdual` in `as_topy`. Can we also discuss renaming `as_topy` please? It needs a more descriptive name.
